### PR TITLE
fix: add ttl option on typespec to fix dialyzer

### DIFF
--- a/src/aws_signature.erl
+++ b/src/aws_signature.erl
@@ -158,7 +158,7 @@ sign_v4_query_params(AccessKeyID, SecretAccessKey, Region, Service, DateTime, UR
          DateTime :: calendar:datetime(),
          URL :: binary(),
          Options :: [Option],
-         Option :: {uri_encode_path, boolean()} | {session_token, binary()},
+         Option :: {uri_encode_path, boolean()} | {session_token, binary()} | {ttl, non_neg_integer()},
          FinalURL :: binary().
 sign_v4_query_params(AccessKeyID,
                      SecretAccessKey,


### PR DESCRIPTION
Only got to test the new implemented function `sign_v4_query_params` now, and it worked pefectly. Thanks for that @philss !

Just got some error/warning on dialyzer when tried to use the `ttl` option. This small change in the typespecs fixes it