### PR TITLE
Add support for port authority component for OTP>=21

### DIFF
--- a/src/aws_signature.erl
+++ b/src/aws_signature.erl
@@ -876,6 +876,36 @@ sign_v4_query_params_with_body_digest_test() ->
 
     ?assertEqual(Expected, Actual).
 
+sign_v4_query_params_with_authority_port_test() ->
+    AccessKeyID = <<"AKIAIOSFODNN7EXAMPLE">>,
+    SecretAccessKey = <<"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY">>,
+    Region = <<"us-east-1">>,
+    Service = <<"s3">>,
+    DateTime = {{2013, 5, 24}, {0, 0, 0}},
+    Method = <<"GET">>,
+    URL = <<"http://bucket.localhost:9000/test.txt">>,
+
+    Expected =
+        <<"http://bucket.localhost:9000/test.txt?",
+        "X-Amz-Algorithm=AWS4-HMAC-SHA256&",
+        "X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2Fs3%2Faws4_request&",
+        "X-Amz-Date=20130524T000000Z&",
+        "X-Amz-Expires=86400&",
+        "X-Amz-Signature=3dd62e9f64b1c393bfc3d2902e5d5474b629113acd965dbd52ea3d874c83921b&",
+        "X-Amz-SignedHeaders=host">>,
+
+    Actual =
+        sign_v4_query_params(AccessKeyID,
+                             SecretAccessKey,
+                             Region,
+                             Service,
+                             DateTime,
+                             Method,
+                             URL,
+                             [{body_digest, <<"UNSIGNED-PAYLOAD">>}]),
+
+    ?assertEqual(Expected, Actual).
+
 format_date_long_test() ->
     Expected = <<"20210126T200815Z">>,
     Actual = format_datetime_long({{2021,1,26}, {20,8,15}}),

--- a/src/aws_signature.erl
+++ b/src/aws_signature.erl
@@ -906,6 +906,36 @@ sign_v4_query_params_with_authority_port_test() ->
 
     ?assertEqual(Expected, Actual).
 
+sign_v4_query_params_with_authority_well_known_port_test() ->
+    AccessKeyID = <<"AKIAIOSFODNN7EXAMPLE">>,
+    SecretAccessKey = <<"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY">>,
+    Region = <<"us-east-1">>,
+    Service = <<"s3">>,
+    DateTime = {{2013, 5, 24}, {0, 0, 0}},
+    Method = <<"GET">>,
+    URL = <<"http://bucket.localhost:80/test.txt">>,
+
+    Expected =
+        <<"http://bucket.localhost:80/test.txt?",
+        "X-Amz-Algorithm=AWS4-HMAC-SHA256&",
+        "X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2Fs3%2Faws4_request&",
+        "X-Amz-Date=20130524T000000Z&",
+        "X-Amz-Expires=86400&",
+        "X-Amz-Signature=12778f8b6fc2cb5cce0fee8b218428fb8261c99a145613232d47be9aa38d1d85&",
+        "X-Amz-SignedHeaders=host">>,
+
+    Actual =
+        sign_v4_query_params(AccessKeyID,
+                             SecretAccessKey,
+                             Region,
+                             Service,
+                             DateTime,
+                             Method,
+                             URL,
+                             [{body_digest, <<"UNSIGNED-PAYLOAD">>}]),
+
+    ?assertEqual(Expected, Actual).
+
 format_date_long_test() ->
     Expected = <<"20210126T200815Z">>,
     Actual = format_datetime_long({{2021,1,26}, {20,8,15}}),

--- a/src/aws_signature_utils.erl
+++ b/src/aws_signature_utils.erl
@@ -116,8 +116,8 @@ uri_encode_path_byte(Byte) ->
 
 %% @doc Formats the port number (if present).
 %%
-%% If the port is defined and is not a "standard port" like 80 or 443,
-%% converts it to binary and prepends a colon. Otherwise, return an empty binary.
+%% If the port is defined and is not a "standard port" (like 80 or 443),
+%% converts it to binary and prepends a colon. Otherwise, returns an empty binary.
 -spec format_port(integer() | undefined) -> binary().
 format_port(undefined) -> <<>>;
 format_port(80) -> <<>>;

--- a/src/aws_signature_utils.erl
+++ b/src/aws_signature_utils.erl
@@ -55,7 +55,16 @@ hex(N, upper) when N < 16 ->
 -ifdef(OTP_RELEASE). % OTP >= 21
   parse_url(URL) when is_binary(URL) ->
     #{host := Host, path := Path} = P = uri_string:parse(URL),
-    #{host => Host, path => Path, query => maps:get(query, P, <<>>)}.
+
+    FinalHost =
+        case maps:get(port, P, undefined) of
+            undefined -> Host;
+            Port ->
+                FinalPort = list_to_binary(integer_to_list(Port)),
+                <<Host/binary, ":", FinalPort/binary>>
+        end,
+
+    #{host => FinalHost, path => Path, query => maps:get(query, P, <<>>)}.
 -else. % OTP < 21
   parse_url(URL) when is_binary(URL) ->
     %% From https://datatracker.ietf.org/doc/html/rfc3986#appendix-B


### PR DESCRIPTION
After a quite long debugging session, I've found out that `aws_signature` doesn't take the port number into account when calculating the signature.

Example: my setup is a local MinIO instance, and signing a URL like `http://localhost:9000/bucket/test.txt` using `:aws_signature.sign_v4_query_params` always results in:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<Error>
   <Code>SignatureDoesNotMatch</Code>
   <Message>The request signature we calculated does not match the signature you provided. Check your key and signing method.</Message>
   <Key>test.txt</Key>
   <BucketName>bucket</BucketName>
   <Resource>/bucket/test.txt</Resource>
   <Region>us-east-1</Region>
   <RequestId>16E9AFDC6B4E7030</RequestId>
   <HostId>67bc3812-391a-46d8-bccc-f119d5db2dac</HostId>
</Error>
```

This PR fixes this. And, just in case – the algorithm for OTP < 21 works as expected 😄 

EDIT: I've found out that "standard" ports should not be used when signing requests for AWS. So the OTP < 21 algorithm may need adjustment to strip `:80/:443`.