### PR TITLE
Fix dialyzer error in the sign_v4_event/7 spec

### DIFF
--- a/src/aws_signature.erl
+++ b/src/aws_signature.erl
@@ -137,7 +137,7 @@ sign_v4(AccessKeyID, SecretAccessKey, Region, Service, DateTime, Method, URL, He
          PriorSignature :: binary(),
          HeaderString :: binary(),
          Body :: binary(),
-         Headers :: headers(),
+         Headers :: [{binary(), binary(), atom()}],
          Signature :: binary().
 sign_v4_event(SecretAccessKey, Region, Service, DateTime, PriorSignature, HeaderString, Body)
     when is_binary(SecretAccessKey),


### PR DESCRIPTION
The returned headers are custom and do not match the headers() type.

Fixes the following warning when running `rebar3 dialyzer` on this repo:

```
===> Analyzing 2 files with _build/default/rebar3_27.3_plt...

src/aws_signature.erl
Line 132 Column 2: Invalid type specification for function aws_signature:sign_v4_event/7. The success typing is (bina\
ry(),binary(),binary(),{{non_neg_integer(),1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12,1..255},{byte(),byte(),by\
te()}},binary(),binary(),binary()) -> {[{<<_:40,_:_*88>>,binary() | {_,_},'byte_array' | 'timestamp'},...],binary()} \
but the spec is (SecretAccessKey,Region,Service,DateTime,PriorSignature,HeaderString,Body) -> {Headers,Signature} whe\
n SecretAccessKey :: binary(), Region :: binary(), Service :: binary(), DateTime :: calendar:datetime(), PriorSignatu\
re :: binary(), HeaderString :: binary(), Body :: binary(), Headers :: headers(), Signature :: binary()
===> Warnings written to _build/default/27.3.dialyzer_warnings
===> Warnings occurred running dialyzer: 1
```