### PR TITLE
Fix SigV4a signature

### DIFF
--- a/src/aws_sigv4_internal.erl
+++ b/src/aws_sigv4_internal.erl
@@ -224,7 +224,7 @@ build_string_to_sign(Signer, CanonicalRequest) ->
                [ Signer#internal_signer.algorithm
                , aws_sigv4_utils:format_time_long(Signer#internal_signer.time)
                , Signer#internal_signer.credential_scope
-               , aws_sigv4_utils:sha256(CanonicalRequest)
+               , aws_signature_utils:base16(aws_sigv4_utils:sha256(CanonicalRequest))
                ])).
 
 -spec build_authorization_header(internal_signer(), binary(), binary()) -> binary().

--- a/src/aws_sigv4a.erl
+++ b/src/aws_sigv4a.erl
@@ -92,7 +92,7 @@ scope(Time, Service) ->
 -spec sign_string(binary()) -> aws_sigv4_internal:sign_string().
 sign_string(PrivateKey) ->
   fun(StrToSign) ->
-    {ok, aws_signature_utils:base16(ecdsa_sign(PrivateKey, aws_sigv4_utils:sha256(StrToSign)))}
+    {ok, aws_signature_utils:base16(ecdsa_sign(PrivateKey, StrToSign))}
   end.
 
 ecdsa_sign(PrivateKey, Digest) ->

--- a/test/aws_sigv4a_tests.erl
+++ b/test/aws_sigv4a_tests.erl
@@ -276,7 +276,7 @@ expect_signature(Headers, TT) ->
   Credentials = TT#sign_request_test.input#v4a_sign_request_input.credentials,
   {ok, PrivateKey} = aws_sigv4a_credentials:derive_private_key(Credentials),
   PublicKey = public_key(PrivateKey),
-  verify_signature(PublicKey, aws_sigv4_utils:sha256(TT#sign_request_test.string_to_sign), Signature).
+  verify_signature(PublicKey, TT#sign_request_test.string_to_sign, Signature).
 
 public_key(PrivateKey) ->
   {PublicKey, _PrivateKey} = crypto:generate_key(ecdh, secp256r1, PrivateKey),


### PR DESCRIPTION
## Problem

The current SigV4a implementation has two critical bugs that cause `SignatureDoesNotMatch` errors when making requests to AWS services:

1. **Double hashing in signature calculation** - The code pre-hashes StringToSign before passing it to `crypto:sign/4`, which internally hashes it again
2. **Missing hex-encoding in StringToSign** - The CanonicalRequest hash in StringToSign is not hex-encoded, causing binary data to be included directly in the string

## Root Cause

### Issue 1: Double Hashing

```erlang
% Before (incorrect - double hashing)
{ok, aws_signature_utils:base16(ecdsa_sign(PrivateKey, aws_sigv4_utils:sha256(StrToSign)))}

% After (correct - single hashing)
{ok, aws_signature_utils:base16(ecdsa_sign(PrivateKey, StrToSign))}
```

The code was pre-hashing StringToSign, then `crypto:sign(ecdsa, sha256, ...)` hashes it again internally, resulting in double hashing.

### Issue 2: Missing Hex-Encoding

```erlang
% Before (incorrect - raw binary hash)
, aws_sigv4_utils:sha256(CanonicalRequest)

% After (correct - hex-encoded hash)
, aws_signature_utils:base16(aws_sigv4_utils:sha256(CanonicalRequest))
```

The Go reference implementation uses `hex.EncodeToString()` to convert the hash to a hex string, but this was missed during the Erlang port.

## Reference

- Go implementation (smithy-go):
    - StringToSign construction: https://github.com/aws/smithy-go/blob/ddbac1c617ac6bea513c16923e7883b1439b2a34/aws-http-auth/internal/v4/signer.go#L212-L219
  - SigV4a signing: https://github.com/aws/smithy-go/blob/ddbac1c617ac6bea513c16923e7883b1439b2a34/aws-http-auth/sigv4a/sigv4a.go#L195-L200
